### PR TITLE
Fix completion for Mac Os X

### DIFF
--- a/pip
+++ b/pip
@@ -5,7 +5,7 @@ _pip() {
     first="${COMP_WORDS[0]}"
 
     commands=$($first --help | awk '/Commands\:/,/General Options\:/' | \
-               \grep -E -o "^\s{2}\w*" | tr -d ' ')
+               \grep -E -o "^\s{2}\w+" | tr -d ' ')
     opts=$($first --help | \grep -E -o "((-\w{1}|--(\w|-)*=?)){1,2}")
 
 


### PR DESCRIPTION
Due to some unclear reasons, grep from Mac OS X finds the matching for "^" after previous matched part. So, every two spaces after command name appears in result. Moreover, first word of command description may appears in result, if line has even number of spaces between command name and description.
I think proposed patch shouldn't break something in other systems, because command name should contain at least one alphanumeric character, so "\w+" will be matched all required cases.
