### PR TITLE
add local qualifiers to vars as fix for zsh

### DIFF
--- a/pip
+++ b/pip
@@ -1,5 +1,6 @@
 
 _pip() {
+    local cur prev commands opts
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     first="${COMP_WORDS[0]}"
@@ -15,7 +16,8 @@ _pip() {
     fi
 
     if [[ ${cur} == -* ]] ; then
-        local command_opts=$($first $prev --help | \
+	local command_opts
+        command_opts=$($first $prev --help | \
                              \grep -E -o "((-\w{1}|--(\w|-)*=?)){1,2}")
         COMPREPLY=( $(compgen -W "${command_opts}" -- ${cur}) )
         return 0
@@ -26,4 +28,4 @@ complete -o default -F _pip pip
 complete -o default -F _pip pip2
 complete -o default -F _pip pip3
 
-# /* vim: set filetype=sh : */
+# /* vim: set filetype=sh ts=8: */


### PR DESCRIPTION
Just a few minor edits to get it to work with zsh (5.2 on osx).

The change at 19-20 is probably really a workaround for some obscure zsh bug as I believe the existing definition was equivalent but regardless it was necessary.

Oh I also added ts=8 to the vim modeline after aborting my first pull request due to misalignment.
(file is a bit of a mix of tabs and spaces but I figured it'd be presumptuous to reformat it too!)
