### PR TITLE
Fix awk warning regexp escape sequence

### DIFF
--- a/pip
+++ b/pip
@@ -5,7 +5,7 @@ _pip() {
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     first="${COMP_WORDS[0]}"
 
-    commands=$($first --help | awk '/Commands\:/,/General Options\:/' | \
+    commands=$($first --help | awk '/Commands:/,/General Options:/' | \
                \grep -E -o "^\s{2}\w+" | tr -d ' ')
     opts=$($first --help | \grep -E -o "((-\w{1}|--(\w|-)*=?)){1,2}")
 


### PR DESCRIPTION
### env 
On Mac, installed this package using `brew`. GNU txtutils provides `awk` (from `gawk`). 

Example **before** fix, hitting TAB after `pip install`:
~~~bash
$ pip install awk: cmd. line:1: warning: regexp escape sequence `\:' is not a known regexp operator
~~~

Removed the backslashes '\' line 8.

Example **after** fix, works like a charm:
~~~bash
$ pip install --r
--require-hashes  --requirement     --retries         --root            
~~~

Thank you for your effort